### PR TITLE
Fix template file name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Features
 
 Documentation
 =============
-The documentation is contained within inline comments in the various files, but especially index.html
+The documentation is contained within inline comments in the various files, but especially main-template.html.
 
 Contribute
 ==========


### PR DESCRIPTION
Change the referenced template file name from index.html to main-template.html
